### PR TITLE
Improve DBNet README.md (#467)

### DIFF
--- a/dbnet/README.md
+++ b/dbnet/README.md
@@ -3,19 +3,20 @@
 The Pytorch implementation is [DBNet](https://github.com/BaofengZan/DBNet.pytorch).
 
 <p align="center">
-<img src="https://user-images.githubusercontent.com/20653176/100968101-b044be00-356b-11eb-808c-9597cbe1f8de.jpg">
+<img src="https://user-images.githubusercontent.com/25873202/113959270-1eb8c600-9855-11eb-9c4d-1e6dc8e38a17.jpg">
 </p>
+
 
 
 ## How to Run
 
-* 1. generate .wts
+* 1. generate `.wts`
 
   Download code and model from [DBNet](https://github.com/BaofengZan/DBNet.pytorch) and config your environments.
 
-  In tools/predict.py, set `save_wts` as `True`, and run, the .wts will be generated.
+  Go to file`tools/predict.py`, set `--save_wts` as `True`, then run, the `DBNet.wts` will be generated.
 
-  onnx can also be exported, just need to set `onnx` as `True`.
+  Onnx can also be exported, just need to set `--onnx` as `True`.
 
 * 2. cmake and make
 
@@ -24,28 +25,32 @@ The Pytorch implementation is [DBNet](https://github.com/BaofengZan/DBNet.pytorc
   cd build
   cmake ..
   make
+  cp /your_wts_path/DBNet.wts .
   sudo ./dbnet -s             // serialize model to plan file i.e. 'DBNet.engine'
-  sudo ./dbnet -d  ../samples // deserialize plan file and run inference, the images in samples will be processed.
+  sudo ./dbnet -d  ./test_imgs // deserialize plan file and run inference, all images in test_imgs folder will be processed.
   ```
+
 
 
 ## For windows
 
 https://github.com/BaofengZan/DBNet-TensorRT
 
+
+
 ## Todo
 
-* 1. ~~In common.hpp, the following two functions can be merged.~~
+- [x] 1. In `common.hpp`, the following two functions can be merged.
 
-```c++
-ILayer* convBnLeaky(INetworkDefinition *network, std::map<std::string, Weights>& weightMap, ITensor& input, int outch, int ksize, int s, int g, std::string lname, bool bias = true) 
-```
+     ```c++
+     ILayer* convBnLeaky(INetworkDefinition *network, std::map<std::string, Weights>& weightMap, ITensor& input, int outch, int ksize, int s, int g, std::string lname, bool bias = true) 
+     ```
 
-```c++
-ILayer* convBnLeaky2(INetworkDefinition *network, std::map<std::string, Weights>& weightMap, ITensor& input, int outch, int ksize, int s, int g, std::string lname, bool bias = true)
-```
+     ```c++
+     ILayer* convBnLeaky2(INetworkDefinition *network, std::map<std::string, Weights>& weightMap, ITensor& input, int outch, int ksize, int s, int g, std::string lname, bool bias = true)
+     ```
 
-* 2. The postprocess method here should be optimized, which is a little different from pytorch side.
+- [x] 2. The postprocess method here should be optimized, which is a little different from pytorch side.
 
-* 3. ~~The input image here is resized to 640x640 directly, while the pytorch side is using `letterbox` method.~~
+- [x] 3. The input image here is resized to `640 x 640` directly, while the pytorch side is using `letterbox` method.
 


### PR DESCRIPTION
* Fix: syntax error in common.hpp , cuda & tensorrt not included in CMakeLists.txt

* Fix: layer warining while building in common.hpp and denet.cpp

* Fix: NOT droping mini boxes and low score boxes.

* Fix: The prediction boxes are NOT expanded by the specified proportion, which will lead to serious errors

* Improve DBNet README

* Improve DBNet README

* Improve DBNet README